### PR TITLE
Fix Input Message Overwrite Bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,50 @@
 cryptojs
 --------
 
-* with little modification, converted from googlecode project [crypto-js](http://code.google.com/p/crypto-js/), and keep the source code structure of the origin project on googlecode
-* source code worked in both browser engines and node scripts. see also: [https://github.com/gwjjeff/crypto-js-npm-conv](https://github.com/gwjjeff/crypto-js-npm-conv)
-* inspiration comes from [ezcrypto](https://github.com/ElmerZhang/ezcrypto), but my tests cannot pass with his version ( ECB/pkcs7 mode ), so I made it myself
+This fork clarifies some behavior which is slightly
+counterintuitive based on the [CryptoJS
+documentation](http://code.google.com/p/crypto-js/), and modifies
+some confusing behavior.
 
 ### install
 
 ```
 npm install cryptojs
+# For tests you need Mocha and Should
+npm install mocha
+npm install should
+```
+
+### Differences from CryptoJS
+
+#### Block Cipher Return Values
+
+CryptoJS returns a CipherParams object as the result of
+encryption. This library handles things somewhat differently.
+
+If the `asBytes` option is set to true, an array of byte values
+is returned. Otherwise a Base64 encoded string is returned. 
+
+If no `iv` option is provided, the generated IV is prepended to
+the result (which is either a byte array or a string depending on
+the `asBytes` parameter).
+
+#### In-place Encryption
+
+By default the result returned is a copy of the input bytes.
+However, if the `in_place` option is set to true and the
+message is passed as a byte array, the message will be encrypted
+in place (i.e. the array the message points to will be replaced).
+
+```coffee
+Crypto = (require 'cryptojs').Crypto
+key = '12345678'
+us = 'Hello, 世界!'
+
+mode = new Crypto.mode.ECB Crypto.pad.pkcs7
+
+ub = Crypto.charenc.UTF8.stringToBytes us
+eb = Crypto.DES.encrypt ub, key, {asBytes: true, mode: mode, in_place: true}  # << This will set 'ub' equal to 'eb'
 ```
 
 ### usage (example with [coffee-script](http://coffeescript.org/))
@@ -30,3 +66,8 @@ us2= Crypto.charenc.UTF8.bytesToString ub2
 # should be same as the var 'us'
 console .log us2
 ```
+
+### Acks 
+* with little modification, converted from googlecode project [crypto-js](http://code.google.com/p/crypto-js/), and keep the source code structure of the origin project on googlecode
+* source code worked in both browser engines and node scripts. see also: [https://github.com/gwjjeff/crypto-js-npm-conv](https://github.com/gwjjeff/crypto-js-npm-conv)
+* inspiration comes from [ezcrypto](https://github.com/ElmerZhang/ezcrypto), but my tests cannot pass with his version ( ECB/pkcs7 mode ), so I made it myself

--- a/lib/AES.js
+++ b/lib/AES.js
@@ -118,6 +118,8 @@ var AES = C.AES = {
 				password
 			);
 
+    AES.check_key(k)
+
 		// Encrypt
 		AES._init(k);
 		mode.encrypt(AES, m, iv);
@@ -159,6 +161,7 @@ var AES = C.AES = {
 				password
 			);
 
+    AES.check_key(k)
 		// Decrypt
 		AES._init(k);
 		mode.decrypt(AES, c, iv);
@@ -329,6 +332,11 @@ var AES = C.AES = {
 
 	},
 
+  check_key: function(k) {
+    if (k.length != 16 && k.length != 24 && k.length != 32) {
+      throw new RangeError("Invalid key length. AES supports 128, 192, and 256 bit keys")
+    }
+  },
 
 	/**
 	 * Private methods

--- a/lib/AES.js
+++ b/lib/AES.js
@@ -103,7 +103,7 @@ var AES = C.AES = {
 			m = (
 				message.constructor == String ?
 				UTF8.stringToBytes(message) :
-				message
+				options.in_place ? message : message.slice()
 			),
 
 			// Generate random IV

--- a/lib/AES.js
+++ b/lib/AES.js
@@ -125,7 +125,7 @@ var AES = C.AES = {
 		mode.encrypt(AES, m, iv);
 
 		// Return ciphertext
-		m = options.iv ? m : iv.concat(m);
+    if (!options.iv) m.unshift.apply(m,iv)
 		return (options && options.asBytes) ? m : util.bytesToBase64(m);
 
 	},

--- a/lib/DES.js
+++ b/lib/DES.js
@@ -942,7 +942,7 @@ var C = (typeof window === 'undefined') ? require('./Crypto').Crypto : window.Cr
             mode.encrypt(DES, m, iv);
 
             // Return ciphertext
-            m = options.iv ? m : iv.concat(m);
+            if (!options.iv) m.unshift.apply(m,iv)
             return (options && options.asBytes) ? m : util.bytesToBase64(m);
         },
 

--- a/lib/DES.js
+++ b/lib/DES.js
@@ -921,7 +921,7 @@ var C = (typeof window === 'undefined') ? require('./Crypto').Crypto : window.Cr
             var
             // Convert to bytes if message is a string
             m = (message.constructor == String ? UTF8.stringToBytes(message)
-                    : message),
+                    : options.in_place ? message : message.slice()),
 
             // Generate random IV
             iv = options.iv || util.randomBytes(8),

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
     "node": "*"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {"mocha","should"}
 }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
     "node": "*"
   },
   "dependencies": {},
-  "devDependencies": {"mocha","should"}
+  "devDependencies": {"mocha":"*","should":"*"}
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--reporter spec --compilers coffee:coffee-script

--- a/test/test_mocha.coffee
+++ b/test/test_mocha.coffee
@@ -1,0 +1,62 @@
+Crypto = (require '../cryptojs').Crypto
+should = require 'should'
+
+key = '12345678'
+us = 'Hello, 世界!'
+us_bytes = [72,101,108,108,111,44,32,228,184,150,231,149,140,33]
+ehs = "4d6add118ed63ed4799d3719976fa7cb"
+
+
+describe 'charenc', ->
+  it 'should convert UTF to bytes', ->
+    ub = Crypto.charenc.UTF8.stringToBytes us
+    ub.should.eql us_bytes
+
+  it 'should convert bytes to UTF8',->
+    utf = Crypto.charenc.UTF8.bytesToString us_bytes
+    utf.should.eql us
+
+describe 'util',->
+  ascii = 'james'
+  ascii_b = Crypto.charenc.UTF8.stringToBytes ascii
+  b64 = 'amFtZXM='
+  describe 'base64',->
+    it "should encode '#{ascii_b}' to '#{b64}'", ->
+      eb64 = Crypto.util.bytesToBase64 ascii_b
+      eb64.should.eql b64
+
+    it "should decode '#{b64}' to '#{ascii_b}'", ->
+      asc = Crypto.util.base64ToBytes b64
+      asc.should.eql ascii_b
+
+describe 'Cipher', ->
+  mode = new Crypto.mode.ECB Crypto.pad.pkcs7
+  describe 'encrypt', ->
+    describe 'with options provided', ->
+      it 'should return a byte string with asBytes=true', ->
+        eb = Crypto.DES.encrypt us_bytes, key, {asBytes: true, mode: mode}
+        eb.should.eql [77,106,221,17,142,214,62,212,121,157,55,25,151,111,167,203]
+
+      it 'should return a base64 string if asBytes not given', ->
+        eb = Crypto.DES.encrypt us_bytes, key, {mode: mode}
+        eb64 = Crypto.util.bytesToBase64 [77,106,221,17,142,214,62,212,121,157,55,25,151,111,167,203]
+        eb.should.eql eb64
+
+      it 'should not overwrite input byte array as a side effect',->
+        tmp = us_bytes
+        eb = Crypto.DES.encrypt tmp, key, {asBytes: true, mode: mode}
+        tmp.should.eql [72,101,108,108,111,44,32,228,184,150,231,149,140,33]
+        eb.should.eql [77,106,221,17,142,214,62,212,121,157,55,25,151,111,167,203]
+
+      it 'should overwrite the input byte array if in_place is given', ->
+        tmp = us_bytes.slice()
+        eb = Crypto.DES.encrypt tmp, key, {asBytes: true, mode: mode, in_place: true}
+        tmp.should.eql [77,106,221,17,142,214,62,212,121,157,55,25,151,111,167,203]
+        eb.should.eql [77,106,221,17,142,214,62,212,121,157,55,25,151,111,167,203]
+
+    describe 'without options', ->
+      it 'should default to OFB mode with a generated iv', ->
+        es = Crypto.DES.encrypt us_bytes, key
+
+        db = Crypto.DES.decrypt Crypto.util.base64ToBytes(es), key, {asBytes: true}
+        db.should.eql us_bytes

--- a/test/test_mocha.coffee
+++ b/test/test_mocha.coffee
@@ -59,6 +59,9 @@ describe 'Cipher', ->
             tmp = us_bytes.slice()
             eb = crypt_fn.encrypt tmp, key, {asBytes: true, mode: mode, in_place: true}
             eb.should.eql tmp
+            eb.should.equal tmp
+
+
 
       describe "#{crypt_name} without options", ->
         it 'should default to OFB mode with a generated iv', ->

--- a/test/test_mocha.coffee
+++ b/test/test_mocha.coffee
@@ -31,9 +31,9 @@ describe 'util',->
 
 describe 'Cipher', ->
   mode = new Crypto.mode.ECB Crypto.pad.pkcs7
-  describe 'encrypt', ->
-    for [crypt_name,crypt_fn] in [["DES", Crypto.DES], ["AES",Crypto.AES]]
-      do (crypt_name,crypt_fn)->
+  for [crypt_name,crypt_fn] in [["DES", Crypto.DES], ["AES",Crypto.AES]]
+    do (crypt_name,crypt_fn)->
+      describe 'encrypt', ->
         describe "#{crypt_name} with options provided", ->
           enc_b = null
           it 'should return a byte string with asBytes=true', ->
@@ -66,3 +66,29 @@ describe 'Cipher', ->
 
           db = crypt_fn.decrypt Crypto.util.base64ToBytes(es), key, {asBytes: true}
           db.should.eql us_bytes
+
+  describe 'AES check_keys',->
+    it 'should throw an error with an invalid key length',->
+      invalid_key = [91,92,93,94]
+      (()->
+        es = crypt_fn.encrypt us_bytes, invalid_key
+      ).should.throw()
+
+    it 'should not throw an error with valid key lengths',->
+      valid_key_16 = [1..16]
+      valid_key_24 = [1..24]
+      valid_key_32 = [1..32]
+      (()->
+        es = crypt_fn.encrypt us_bytes, valid_key_16
+      ).should.not.throw()
+      (()->
+        es = crypt_fn.encrypt us_bytes, valid_key_24
+      ).should.not.throw()
+      (()->
+        es = crypt_fn.encrypt us_bytes, valid_key_32
+      ).should.not.throw()
+
+    it 'should expand keys to valid lengths',->
+      (()->
+        es = crypt_fn.encrypt us_bytes, key
+      ).should.not.throw()


### PR DESCRIPTION
Thanks for putting this project together - it's really useful. 

This fixes unexpected behavior I discovered while using block encryption. The input array was always overwritten to be identical to the output. I created an optional parameter which controls this behavior (and disables it by default).

I've also updated the README a bit to clarify some of the differences between how the CryptoJS API works and how this library's API works.
